### PR TITLE
Port to 1.16.5

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,6 +21,6 @@
   "depends":{
     "fabricloader":">=0.10.8",
     "fabric":"*",
-    "minecraft":"1.16.4"
+    "minecraft":"1.16.x"
   }
 }


### PR DESCRIPTION
Update to support 1.16.5, because there were no breakign changes between 1.16.4 and it.

Requires the same fabric.mod.json for Dynamo API (PR'd) and EngiLib (unable to PR due to an empty repository)